### PR TITLE
WHACK-21: Add encryption option

### DIFF
--- a/sample/weather/source/java/org/jivesoftware/weather/ExternalWeatherComponent.java
+++ b/sample/weather/source/java/org/jivesoftware/weather/ExternalWeatherComponent.java
@@ -15,7 +15,7 @@ public class ExternalWeatherComponent {
     public static void main(String[] args) {
         // Create a manager for the external components that will connect to the server "localhost"
         // at the port 5225
-        final ExternalComponentManager manager = new ExternalComponentManager("localhost", 5275);
+        final ExternalComponentManager manager = new ExternalComponentManager("localhost", 5275, false);
         // Set the secret key for this component. The server must be using the same secret key
         // otherwise the component won't be able to authenticate with the server. Check that the
         // server has the property "component.external.secretKey" defined and that it is using the

--- a/sample/weatherabstract/source/java/org/jivesoftware/weather/ExternalWeatherComponent.java
+++ b/sample/weatherabstract/source/java/org/jivesoftware/weather/ExternalWeatherComponent.java
@@ -3,6 +3,14 @@ package org.jivesoftware.weather;
 import org.jivesoftware.whack.ExternalComponentManager;
 import org.xmpp.component.ComponentException;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
 /**
  * This is an example of how to make a component run as an external component. This examples
  * requires that the server be running in the same computer where this application will run and
@@ -14,8 +22,8 @@ public class ExternalWeatherComponent {
 
     public static void main(String[] args) {
         // Create a manager for the external components that will connect to the server "localhost"
-        // at the port 5225
-        final ExternalComponentManager manager = new ExternalComponentManager("localhost", 5275);
+        // at the port 5276, using encryption.
+        final ExternalComponentManager manager = new ExternalComponentManager("localhost", 5276, true);
         // Set the secret key for this component. The server must be using the same secret key
         // otherwise the component won't be able to authenticate with the server. Check that the
         // server has the property "component.external.secretKey" defined and that it is using the

--- a/source/java/org/jivesoftware/whack/ExternalComponentManager.java
+++ b/source/java/org/jivesoftware/whack/ExternalComponentManager.java
@@ -57,6 +57,12 @@ public class ExternalComponentManager implements ComponentManager {
      * Port of the server used for establishing new connections.
      */
     private int port;
+
+    /**
+     * Defines if sockets are started in encrypted mode ("old-style" TLS/SSL, non-STARTTLS
+     */
+    private boolean startEncrypted;
+
     /**
      * Keeps the domain of the XMPP server. The domain may or may not match the host. The domain
      * will be used mainly for the XMPP packets while the host is used mainly for creating
@@ -117,12 +123,27 @@ public class ExternalComponentManager implements ComponentManager {
      * @param host the IP address or name of the XMPP server to connect to (e.g. "example.com").
      * @param port the port to connect on.
      */
+    @Deprecated
     public ExternalComponentManager(String host, int port) {
         if (host == null) {
             throw new IllegalArgumentException("Host of XMPP server cannot be null");
         }
         this.host = host;
         this.port = port;
+
+        createDummyLogger();
+
+        // Set this ComponentManager as the current component manager
+        ComponentManagerFactory.setComponentManager(this);
+    }
+
+    public ExternalComponentManager(String host, int port, boolean startEncrypted) {
+        if (host == null) {
+            throw new IllegalArgumentException("Host of XMPP server cannot be null");
+        }
+        this.host = host;
+        this.port = port;
+        this.startEncrypted = startEncrypted;
 
         createDummyLogger();
 
@@ -218,7 +239,7 @@ public class ExternalComponentManager implements ComponentManager {
             componentsByDomain.put(subdomain, externalComponent);
             components.put(component, externalComponent);
             // Ask the ExternalComponent to connect with the remote server
-            externalComponent.connect(host, port, subdomain);
+            externalComponent.connect(host, port, subdomain, startEncrypted);
             // Initialize the component
             JID componentJID = new JID(null, externalComponent.getDomain(), null);
             externalComponent.initialize(componentJID, this);

--- a/source/java/org/jivesoftware/whack/container/ServerContainer.java
+++ b/source/java/org/jivesoftware/whack/container/ServerContainer.java
@@ -179,7 +179,7 @@ public class ServerContainer {
             String xmppServerHost = properties.getProperty("xmppServer.host");
             port = properties.getProperty("xmppServer.port");
             int xmppServerPort = (port == null ? 10015 : Integer.parseInt(port));
-            manager = new ExternalComponentManager(xmppServerHost, xmppServerPort);
+            manager = new ExternalComponentManager(xmppServerHost, xmppServerPort, false);
             String serverDomain = properties.getProperty("xmppServer.domain");
             if (serverDomain != null) {
                 manager.setServerName(serverDomain);


### PR DESCRIPTION
This commit adds an option to have the connection between the XMPP server and
the external component be encrypted. Note that this does not employ STARTTLS,
but 'natively' born encrypted sockets.