### PR TITLE
Update slf4j to 1.7.32 (CVE-2018-8088)

### DIFF
--- a/sample/weather/pom.xml
+++ b/sample/weather/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>[1.5.8,)</version>
+            <version>1.7.32</version>
             <scope>runtime</scope>
         </dependency>
 	</dependencies>

--- a/sample/weatherabstract/pom.xml
+++ b/sample/weatherabstract/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>[1.5.8,)</version>
+			<version>1.7.32</version>
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Update slf4j to 1.7.32 (CVE-2018-8088):
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088
- http://www.slf4j.org/news.html