### PR TITLE
Update minimum version of Java from 5 to 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.14.0</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Modern JVMs fail to support Java 5, reporting errors like:

```
[ERROR] Source option 5 is no longer supported. Use 7 or later.
[ERROR] Target option 5 is no longer supported. Use 7 or later.
```

This commit updates the minimum version of Java to 7.